### PR TITLE
Parse empty value lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ binaryOperator =  optionalSpace, "==", optionalSpace
 
 valueExpr = singleValue | multipleValues ;
 
-multipleValues = optionalSpace, "{", singleValue,  { "," singleValue }, "}", optionalSpace ;
+multipleValues = optionalSpace, "{", (singleValue, { "," singleValue } | optionalSpace), "}", optionalSpace ;
 
 singleValue = optionalSpace, '"', {([:print:] - '"' - '\' | '\"' | '\\')}, '"', optionalSpace ;
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The **value** can either be a single value (enclosed in quotation marks) or mult
 In the case of multiple values you can read the filter as **OR** statement, e.g. "If status either equals value A *or* value B" and
 "If the subject either contains foo *or* if it contains bar".
 
+Note that in case of an empty list of values (e.g. `status == { }`, there is nothing to compare against and therefore
+such a condition will always evaluate to false.
+
 In the case of referenced properties - like the status - you can either specify the Link-URL as provided by the **APIv3** as a value
 or the **ID** of the referenced ressource.
 

--- a/lib/oql/parser.rb
+++ b/lib/oql/parser.rb
@@ -35,10 +35,10 @@ class Parser < Parslet::Parser
 
   rule(:valueList)  {
                       spaced(
-                        str('{') >>
-                        value >> (str(',') >> value).repeat >>
+                        str('{') >> space? >>
+                        (value >> (str(',') >> value).repeat).maybe >>
                         str('}')
-                      )
+                      ).as(:valueList)
                     }
 
   rule(:andOp)      { spaced(str('&&')) }

--- a/spec/integration/oql_spec.rb
+++ b/spec/integration/oql_spec.rb
@@ -59,6 +59,40 @@ describe 'OQL' do
     expect(OQL.parse(query)).to eql expected
   end
 
+  it 'returns a valid tree for a query with a single multi-value'do
+    query = 'status == { "1" }'
+    expected = {
+      filters: [
+        {
+          condition: {
+            field: 'status',
+            operator: :is_equal,
+            values: [ "1" ]
+          }
+        }
+      ]
+    }
+
+    expect(OQL.parse(query)).to eql expected
+  end
+
+  it 'returns a valid tree for a query without value'do
+    query = 'status == { }'
+    expected = {
+      filters: [
+        {
+          condition: {
+            field: 'status',
+            operator: :is_equal,
+            values: [ ]
+          }
+        }
+      ]
+    }
+
+    expect(OQL.parse(query)).to eql expected
+  end
+
   it 'throws a ParsingFailed error on invalid input' do
     query = 'this is not a query!'
 

--- a/spec/integration/oql_spec.rb
+++ b/spec/integration/oql_spec.rb
@@ -67,7 +67,7 @@ describe 'OQL' do
           condition: {
             field: 'status',
             operator: :is_equal,
-            values: [ "1" ]
+            values: ['1']
           }
         }
       ]
@@ -84,7 +84,7 @@ describe 'OQL' do
           condition: {
             field: 'status',
             operator: :is_equal,
-            values: [ ]
+            values: []
           }
         }
       ]

--- a/spec/unit/oql/parser_valuelists_spec.rb
+++ b/spec/unit/oql/parser_valuelists_spec.rb
@@ -22,6 +22,10 @@ describe 'Parser' do
   describe 'valuelist rule' do
     let(:rule) { Parser.new.valueList }
 
+    it 'can contain no values' do
+      expect(rule).to parse('{ }')
+    end
+
     it 'can contain a single value' do
       expect(rule).to parse('{ "1" }')
     end
@@ -38,9 +42,25 @@ describe 'Parser' do
       expect(rule).to parse('   {   "1"   ,   "2"   ,   "3"   }   ')
     end
 
+    it 'can parse empty list with missing whitespace' do
+      expect(rule).to parse('{}')
+    end
+
+    it 'can parse empty list with missing whitespace' do
+      expect(rule).to parse('   {      }   ')
+    end
+
     it 'returns one element per value' do
       tree = rule.parse('{ "1", "2", "3" }')
-      expect(tree.size).to eql 3
+      expect(tree[:valueList].size).to eql 3
+    end
+
+    it 'can not parse extra comma in front of value' do
+      expect(rule).to_not parse('{,"1"}')
+    end
+
+    it 'can not parse extra comma after value' do
+      expect(rule).to_not parse('{"1",}')
     end
   end
 end

--- a/spec/unit/oql/value_list_transform_spec.rb
+++ b/spec/unit/oql/value_list_transform_spec.rb
@@ -15,30 +15,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'oql/parser'
-require 'oql/parsing_failed'
-require 'oql/tree_transform'
 require 'oql/value_list_transform'
-require 'oql/version'
+require 'parslet/rig/rspec'
 
-require 'parslet'
+describe 'TreeTransform' do
+  let(:transform) { ValueListTransform.new }
 
-class OQL
-
-  # Parses the given query string and returns a tree-ish representation of
-  # the given query.
-  #
-  # @param query [String] The query string to be parsed
-  # @return [Hash] A tree-ish representation of the parsed query
-  # @raise [OQL::ParsingFailed] if the query provided was invalid
-  def self.parse(query)
-    begin
-      parse_tree = Parser.new.parse(query)
-    rescue Parslet::ParseFailed => e
-      raise ParsingFailed, e.message
+  describe 'valueList rules' do
+    it 'transforms empty lists' do
+      tree = { valueList: '{ }' }
+      expect(transform.apply(tree)).to eql []
     end
 
-    intermediate_tree = ValueListTransform.new.apply(parse_tree)
-    TreeTransform.new.apply(intermediate_tree)
+    it 'transforms non-empty lists' do
+      tree = { valueList: { valueString: 'foobar!' } }
+      expected = { valueString: 'foobar!' }
+      expect(transform.apply(tree)).to eql expected
+    end
   end
 end


### PR DESCRIPTION
This PR allows OQL to accept empty value lists.
## Progress
- [x] Implement acceptance of empty value lists
- [x] Update Documentation accordingly
